### PR TITLE
feat: add custom toast component functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ function App() {
       <button onClick={() => toast.success('My first toast')}>
         Give me a toast
       </button>
+      <button onClick={() => toast.custom(
+        <div className="p-4 bg-purple-500 text-white rounded-lg">
+          Custom Toast!
+        </div>
+      )}>
+        Custom Toast
+      </button>
     </div>
   );
 }

--- a/apps/web/.source/index.ts
+++ b/apps/web/.source/index.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck -- skip type checking
-import * as docs_2 from "../content/docs/toaster.mdx?collection=docs&hash=1745776312190"
-import * as docs_1 from "../content/docs/toast.mdx?collection=docs&hash=1745776312190"
-import * as docs_0 from "../content/docs/index.mdx?collection=docs&hash=1745776312190"
+import * as docs_2 from "../content/docs/toaster.mdx?collection=docs&hash=1751619699505"
+import * as docs_1 from "../content/docs/toast.mdx?collection=docs&hash=1751619699505"
+import * as docs_0 from "../content/docs/index.mdx?collection=docs&hash=1751619699505"
 import { _runtime } from "fumadocs-mdx"
 import * as _source from "../source.config"
-export const docs = _runtime.docs<typeof _source.docs>([{ info: {"path":"index.mdx","absolutePath":"D:/packages/mtoast/apps/web/content/docs/index.mdx"}, data: docs_0 }, { info: {"path":"toast.mdx","absolutePath":"D:/packages/mtoast/apps/web/content/docs/toast.mdx"}, data: docs_1 }, { info: {"path":"toaster.mdx","absolutePath":"D:/packages/mtoast/apps/web/content/docs/toaster.mdx"}, data: docs_2 }], [{"info":{"path":"meta.json","absolutePath":"D:/packages/mtoast/apps/web/content/docs/meta.json"},"data":{"title":"Basics","pages":["---Introduction---","index","---API---","toast","toaster"],"description":"The docs for the toast","root":true,"icon":"Building2"}}])
+export const docs = _runtime.docs<typeof _source.docs>([{ info: {"path":"index.mdx","absolutePath":"/Users/tum/programming/personal/mtoast/apps/web/content/docs/index.mdx"}, data: docs_0 }, { info: {"path":"toast.mdx","absolutePath":"/Users/tum/programming/personal/mtoast/apps/web/content/docs/toast.mdx"}, data: docs_1 }, { info: {"path":"toaster.mdx","absolutePath":"/Users/tum/programming/personal/mtoast/apps/web/content/docs/toaster.mdx"}, data: docs_2 }], [{"info":{"path":"meta.json","absolutePath":"/Users/tum/programming/personal/mtoast/apps/web/content/docs/meta.json"},"data":{"title":"Basics","pages":["---Introduction---","index","---API---","toast","toaster"],"description":"The docs for the toast","root":true,"icon":"Building2"}}])

--- a/apps/web/.source/source.config.mjs
+++ b/apps/web/.source/source.config.mjs
@@ -1,0 +1,8 @@
+// source.config.ts
+import { defineDocs } from "fumadocs-mdx/config";
+var docs = defineDocs({
+  dir: "content/docs"
+});
+export {
+  docs
+};

--- a/apps/web/components/examples.tsx
+++ b/apps/web/components/examples.tsx
@@ -44,10 +44,21 @@ const examples = [
       toast.information('Information', "Here's something you should know"),
   },
   {
-    name: 'Anything You Want',
+    name: 'Custom Toast',
     icon: <Laugh className="h-5 w-5 text-amber-500" />,
-    action: () => {},
-    // toast.information('Information', "Here's something you should know"),
+    action: () => 
+      toast.custom(
+        <div className="flex items-center space-x-3 p-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg shadow-lg text-white">
+          <div className="flex-shrink-0">
+            <Sparkles className="h-6 w-6" />
+          </div>
+          <div>
+            <h3 className="font-semibold">Custom Toast!</h3>
+            <p className="text-sm opacity-90">This is a completely custom toast component with your own styling and layout!</p>
+          </div>
+        </div>,
+        { duration: 6000 }
+      ),
   },
   {
     name: 'Simple Action',
@@ -70,6 +81,35 @@ const examples = [
           onClick: () => window.open('/features'),
         },
       }),
+  },
+  {
+    name: 'Advanced Custom',
+    icon: <Sparkles className="h-5 w-5 text-indigo-500" />,
+    action: () =>
+      toast.custom(
+        <div className="flex items-start space-x-3 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-md">
+          <div className="flex-shrink-0">
+            <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+              <CheckCircle className="h-5 w-5 text-white" />
+            </div>
+          </div>
+          <div className="flex-1">
+            <h3 className="font-semibold text-gray-900 dark:text-white">File Uploaded Successfully!</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+              Your document has been uploaded and is ready for processing.
+            </p>
+            <div className="mt-3 flex space-x-2">
+              <button className="px-3 py-1.5 bg-blue-500 text-white text-xs font-medium rounded-md hover:bg-blue-600 transition-colors">
+                View File
+              </button>
+              <button className="px-3 py-1.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                Share
+              </button>
+            </div>
+          </div>
+        </div>,
+        { duration: 8000 }
+      ),
   },
   {
     name: 'Loading',

--- a/apps/web/content/docs/toast.mdx
+++ b/apps/web/content/docs/toast.mdx
@@ -125,24 +125,57 @@ toast.loading('Loading data');
 
 ### Custom
 
-You can pass tsx as the first argument instead of a string to render a custom toast while maintaining default styling.
+You can create completely custom toast components using `toast.custom()`. This allows you to pass any React component with your own styling and layout.
 
 ```tsx
-toast(<div>A custom toast with default styling</div>, { duration: 5000 });
+toast.custom(
+  <div className="flex items-center space-x-3 p-4 bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg shadow-lg text-white">
+    <div className="flex-shrink-0">
+      <Sparkles className="h-6 w-6" />
+    </div>
+    <div>
+      <h3 className="font-semibold">Custom Toast!</h3>
+      <p className="text-sm opacity-90">
+        This is a completely custom toast component with your own styling!
+      </p>
+    </div>
+  </div>,
+  { duration: 6000 }
+);
 ```
 
-### Headless
-
-Use it to render an unstyled toast with custom tsx while maintaining the functionality. This function receives the `Toast` as an argument, giving you access to all properties.
+You can also create more complex custom toasts with interactive elements:
 
 ```tsx
-toast.custom((t) => (
-  <div>
-    This is a custom component{' '}
-    <button onClick={() => toast.dismiss(t)}>close</button>
-  </div>
-));
+toast.custom(
+  <div className="flex items-start space-x-3 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-w-md">
+    <div className="flex-shrink-0">
+      <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+        <CheckCircle className="h-5 w-5 text-white" />
+      </div>
+    </div>
+    <div className="flex-1">
+      <h3 className="font-semibold text-gray-900 dark:text-white">
+        File Uploaded Successfully!
+      </h3>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+        Your document has been uploaded and is ready for processing.
+      </p>
+      <div className="mt-3 flex space-x-2">
+        <button className="px-3 py-1.5 bg-blue-500 text-white text-xs font-medium rounded-md hover:bg-blue-600 transition-colors">
+          View File
+        </button>
+        <button className="px-3 py-1.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+          Share
+        </button>
+      </div>
+    </div>
+  </div>,
+  { duration: 8000 }
+);
 ```
+
+**Note:** Custom toasts automatically include a close button positioned at the top-right corner. You don't need to implement your own close functionality.
 
 ### Dynamic Position
 

--- a/packages/mtoast/src/components/toast.tsx
+++ b/packages/mtoast/src/components/toast.tsx
@@ -150,9 +150,8 @@ export function Toast({
   action,
   onRemove,
   position, // Add position prop
+  customComponent,
 }: ToastProps) {
-  const Icon = variantStyles[variant].icon;
-  const styles = variantStyles[variant].styles;
   const animations = getAnimationVariants(position);
 
   useEffect(() => {
@@ -163,6 +162,35 @@ export function Toast({
       return () => clearTimeout(timer);
     }
   }, [duration, id, onRemove]);
+
+  // If it's a custom toast with a custom component, render it
+  if (variant === 'custom' && customComponent) {
+    return (
+      <motion.div
+        layout
+        initial={animations.initial}
+        animate={animations.animate}
+        exit={animations.exit}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+        className="relative"
+        role="alert"
+      >
+        {customComponent}
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => onRemove(id)}
+          className="absolute top-2 right-2 z-10 rounded-lg p-1 transition-colors duration-200 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-white/80 dark:hover:bg-black/20"
+          aria-label="Close notification"
+        >
+          <X className="h-4 w-4" />
+        </motion.button>
+      </motion.div>
+    );
+  }
+
+  const Icon = variantStyles[variant].icon;
+  const styles = variantStyles[variant].styles;
 
   return (
     <motion.div

--- a/packages/mtoast/src/store/toast-store.tsx
+++ b/packages/mtoast/src/store/toast-store.tsx
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { ReactNode } from 'react';
 
 export type ToastVariant =
   | 'success'
@@ -7,7 +8,8 @@ export type ToastVariant =
   | 'warning'
   | 'discovery'
   | 'action'
-  | 'loading';
+  | 'loading'
+  | 'custom';
 
 export interface Toast {
   id: string;
@@ -19,6 +21,7 @@ export interface Toast {
     label: string;
     onClick: () => void;
   };
+  customComponent?: ReactNode;
 }
 
 interface ToastStore {

--- a/packages/mtoast/src/toast.ts
+++ b/packages/mtoast/src/toast.ts
@@ -1,4 +1,5 @@
 import { useToastStore, type ToastVariant } from './store/toast-store';
+import { ReactNode } from 'react';
 
 interface ToastAction {
   label: string;
@@ -8,6 +9,10 @@ interface ToastAction {
 interface ToastOptions {
   duration?: number;
   action?: ToastAction;
+}
+
+interface CustomToastOptions extends ToastOptions {
+  customComponent?: ReactNode;
 }
 
 function createToast(
@@ -26,6 +31,7 @@ function createToast(
       variant: variant!,
       duration: options?.duration ?? 5000,
       action: options?.action,
+      customComponent: (options as CustomToastOptions)?.customComponent,
     });
   } else {
     // Otherwise, first param is message only
@@ -34,6 +40,7 @@ function createToast(
       variant: variant!,
       duration: (messageOrOptions as ToastOptions)?.duration ?? 5000,
       action: (messageOrOptions as ToastOptions)?.action,
+      customComponent: (messageOrOptions as CustomToastOptions)?.customComponent,
     });
   }
 }
@@ -85,6 +92,19 @@ export const toast = {
     options?: ToastOptions,
   ) {
     createToast(titleOrMessage, messageOrOptions, 'loading', options);
+  },
+  custom(
+    component: ReactNode,
+    options?: CustomToastOptions,
+  ) {
+    const { addToast } = useToastStore.getState();
+    addToast({
+      message: '', // Empty message since we're using custom component
+      variant: 'custom',
+      duration: options?.duration ?? 5000,
+      action: options?.action,
+      customComponent: component,
+    });
   },
   dismiss() {
     const { clearToasts } = useToastStore.getState();

--- a/packages/mtoast/src/types.ts
+++ b/packages/mtoast/src/types.ts
@@ -1,9 +1,13 @@
+import { ReactNode } from 'react';
+
 export type ToastVariant =
   | 'success'
   | 'error'
   | 'information'
   | 'warning'
-  | 'discovery';
+  | 'discovery'
+  | 'loading'
+  | 'custom';
 
 export interface ToastData {
   id: string;
@@ -11,4 +15,5 @@ export interface ToastData {
   message: string;
   variant: ToastVariant;
   duration?: number;
+  customComponent?: ReactNode;
 }


### PR DESCRIPTION
**🔍 What does this PR do?**  
- Implements custom toast functionality allowing users to pass custom React components
- Adds `toast.custom()` method to the API
- Maintains full backward compatibility

## Changes
- 🎨 Added custom toast component support
- 📝 Updated documentation with examples
- 🔧 Enhanced TypeScript types
- ✨ Added working examples to demo app

**🛠 Related issue(s)**  
Closes #1

**📸 Screenshot or GIF (if applicable)**  
![image](https://github.com/user-attachments/assets/30bbd4b9-5c92-4813-8d91-dc7a127c396c)


**✅ Checklist**

- [x] Custom toasts render correctly
- [x] Close button works on custom toasts
- [x] Duration settings work properly
- [x] Examples in demo app function correctly
- [x] TypeScript compilation passes
- [x] Backward compatibility maintained

**📝 Additional notes**  
Any other relevant information for the reviewers.
